### PR TITLE
adds minOccurs of 0 for UserDefinedFields

### DIFF
--- a/AllfleXML.Test/AllfleXML.Test.csproj
+++ b/AllfleXML.Test/AllfleXML.Test.csproj
@@ -89,6 +89,9 @@
     <Content Include="TestData\FlexOrder\sample6.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\FlexOrder\sample11.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\FlexOrder\sampleMini.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/AllfleXML.Test/FlexOrder.cs
+++ b/AllfleXML.Test/FlexOrder.cs
@@ -100,6 +100,15 @@ namespace AllfleXML.Test
         }
 
         [TestMethod]
+        public void ImportFlexOrderEmptyUserDefined()
+        {
+            var order = AllfleXML.FlexOrder.Parser.Import(@"TestData\FlexOrder\sample11.xml");
+            Assert.IsNotNull(order);
+            Assert.IsTrue(order.OrderHeaders.Any());
+            Assert.IsTrue(order.OrderHeaders.Select(o => o.OrderLineHeaders.Any()).All(o => o));
+        }
+
+        [TestMethod]
         public void ImportFlexOrderMini()
         {
             // TODO: Restrict this possiblity in the future

--- a/AllfleXML.Test/TestData/FlexOrder/sample11.xml
+++ b/AllfleXML.Test/TestData/FlexOrder/sample11.xml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document>
+<OrderHeader>
+  <CustomerNumber>32000</CustomerNumber>
+  <PremiseID />
+  <Comments>|090612121212|</Comments>
+  <PO>CMIWEB-6251</PO>
+  <ShipToName>Marty &amp; Margret Ranch Co </ShipToName>
+  <ShipToContact>Betty Su</ShipToContact>
+  <ShipToPhone />
+  <ShipToAddress1>6400 Green Rd.</ShipToAddress1>
+  <ShipToAddress2 />
+  <ShipToAddress3 />
+  <ShipToCity>Guadalupe</ShipToCity>
+  <ShipToState>CA</ShipToState>
+  <ShipToPostalCode>93434</ShipToPostalCode>
+  <ShipToCountry>United States</ShipToCountry>
+  <IsRush>true</IsRush>
+  <ShipMethod>UPS</ShipMethod>
+  <ShippingAccountNumber />
+  <EmailListError />
+  <EmailListTrackingInfo />
+  <EmailListEIDInfo />
+  <UserDefined/>
+  <WSOrderId />
+  <Hold>false</Hold>
+  <OrderLineHeader>
+    <SkuName>IMI-FDXOTP982-BG/GESM-G-20</SkuName>
+    <Quantity>10</Quantity>
+    <Template>IMI_9OFGESM1_20</Template>
+    <Comment />
+    <UserDefined/>
+  </OrderLineHeader>
+</OrderHeader>
+</Document>

--- a/AllfleXML/FlexOrder/FlexOrder.xsd
+++ b/AllfleXML/FlexOrder/FlexOrder.xsd
@@ -294,7 +294,7 @@
                 </xs:annotation>
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element name="Field" maxOccurs="unbounded">
+                    <xs:element name="Field" minOccurs="0" maxOccurs="unbounded">
                       <xs:annotation>
                         <xs:appinfo>User Defined Field</xs:appinfo>
                         <xs:documentation xml:lang="en">
@@ -405,7 +405,7 @@
                       </xs:annotation>
                       <xs:complexType>
                         <xs:sequence>
-                          <xs:element name="Field" maxOccurs="unbounded">
+                          <xs:element name="Field" minOccurs="0" maxOccurs="unbounded">
                             <xs:annotation>
                               <xs:appinfo>User Defined Field</xs:appinfo>
                               <xs:documentation xml:lang="en">


### PR DESCRIPTION
When running the FlexOrder.Parser.Import() routine, I'm getting a XmlSchemaValidationException.  This is getting thrown when Import() is running the Parser.Validate() function.  I believe that this is caused when the UserDefined object is missing the "Field" variable, which doesn't have a minimum occurances set.  When I set the minOccurs to 0, it works fine. 